### PR TITLE
Fix workout plan rating validation

### DIFF
--- a/backend/src/models/Nutrition.js
+++ b/backend/src/models/Nutrition.js
@@ -226,7 +226,7 @@ const mealSchema = new mongoose.Schema({
       type: Number,
       min: [1, 'Rating must be at least 1'],
       max: [5, 'Rating cannot exceed 5'],
-      default: 0
+      default: 1
     },
     count: {
       type: Number,

--- a/backend/src/models/Workout.js
+++ b/backend/src/models/Workout.js
@@ -150,7 +150,7 @@ const workoutPlanSchema = new mongoose.Schema({
       type: Number,
       min: [1, 'Rating must be at least 1'],
       max: [5, 'Rating cannot exceed 5'],
-      default: 0
+      default: 1
     },
     count: {
       type: Number,


### PR DESCRIPTION
Fixes `rating.average` validation error by changing the default value from 0 to 1 in both `Workout` and `Nutrition` models.

The `rating.average` field had a `default: 0` but also a `min: [1, 'Rating must be at least 1']` validation rule, causing a conflict when new plans were created. Changing the default to 1 resolves this.

---
<a href="https://cursor.com/background-agent?bcId=bc-ab8e45a5-cb9b-467f-8743-df3aa600c303"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ab8e45a5-cb9b-467f-8743-df3aa600c303"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

